### PR TITLE
Fix error "error: package Build does not exist"

### DIFF
--- a/src/android/PixLive.java
+++ b/src/android/PixLive.java
@@ -9,6 +9,7 @@ import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.graphics.Color;
 import android.media.RingtoneManager;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Looper;
 import android.util.DisplayMetrics;


### PR DESCRIPTION
/platforms/android/src/com/vidinoti/pixlive/PixLive.java:205: package Build does not exist
                    if (Build.VERSION.SDK_INT <= 16) {

```
                         ^
```
